### PR TITLE
leases openstack-cluster

### DIFF
--- a/group_vars/router.yml
+++ b/group_vars/router.yml
@@ -148,6 +148,26 @@ leases:
     - mac: 'b8:27:eb:e1:4b:77'
     - address: '172.23.31.47'
   - host:
+    - name: 'openstack-1'
+    - mac: 'e4:1f:13:c3:0c:df'
+    - address: '172.23.31.141'
+  - host:
+    - name: 'openstack-2'
+    - mac: '1c:6f:65:d0:75:66'
+    - address: '172.23.31.142'
+  - host:
+    - name: 'openstack-3'
+    - mac: 'bc:5f:f4:d6:ed:3a'
+    - address: '172.23.31.143'
+  - host:
+    - name: 'os-4'
+    - mac: '5c:f3:fc:4d:27:9c'
+    - address: '172.23.31.144'
+  - host:
+    - name: 'os-5'
+    - mac: '5c:f3:fc:4d:0d:14'
+    - address: '172.23.31.145'
+  - host:
     - name: 'ap-og-sued'
     - mac: 'f0:9f:c2:f3:00:24'
     - address: '172.23.31.241'


### PR DESCRIPTION
adds static leases for openstack-cluster-server (os-interfaces static leases - secondary interfaces get ip's through dhcp dynamic leases)